### PR TITLE
Release 1.0.0-BETA.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # ArunaCore Changelog
 
+## v1.0.0-BETA.5
+  - [FEAT] Split `401 Unauthorized` into `401 Unauthorized` and `403 Forbidden`  
+    - Now, `401` is used when authentication fails (e.g., invalid secure key), while `403` is used when access is denied despite valid authentication (e.g., insufficient permissions, invalid key for specific target communication, invalid masterkey, etc.). 
+    - This provides clearer feedback to clients about the nature of access issues.
+
+  - [FEAT] Implemented `client.request()` method in `WebSocketClient`  
+    - This method allows sending a message and awaiting a response, simplifying request-response interactions.
+    - To use it, simply call `client.request(message)` and await the returned promise.
+    - To respond to such request on the other side, handle the `request` event and reply using `message.reply`.
+
+  - [CHORE] Improved code documentation and comments for better clarity and maintainability.
+
 ## v1.0.0-BETA.4
 
   - [BREAKING] Dropped support for all versions below Node.js v20.11.1  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # ArunaCore Changelog
 
 ## v1.0.0-BETA.5
+
+  - [FIX] Wrong management of `coreKey`
+    - Fixed an issue where the `coreKey` was handled incorrectly, causing it to be always null, resulting in clients being unable to access restricted resources.
+
   - [FEAT] Split `401 Unauthorized` into `401 Unauthorized` and `403 Forbidden`  
     - Now, `401` is used when authentication fails (e.g., invalid secure key), while `403` is used when access is denied despite valid authentication (e.g., insufficient permissions, invalid key for specific target communication, invalid masterkey, etc.). 
     - This provides clearer feedback to clients about the nature of access issues.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arunacore-api",
-  "version": "1.0.0-BETA.4",
+  "version": "1.0.0-BETA.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "arunacore-api",
-      "version": "1.0.0-BETA.4",
+      "version": "1.0.0-BETA.5",
       "license": "GPL-3.0",
       "dependencies": {
         "@promisepending/logger.js": "^1.1.1",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arunacore-api",
-  "version": "1.0.0-BETA.4",
+  "version": "1.0.0-BETA.5",
   "description": "ArunaCore is an open source websocket server made with nodejs for intercomunication between applications.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/api/src/interfaces/IMessage.ts
+++ b/api/src/interfaces/IMessage.ts
@@ -8,8 +8,7 @@ export interface IMessage {
     id: string,
     key?: string
   },
-  coreKey?: string,
   command?: string,
   args?: string[],
-  content: any
+  content: unknown
 }

--- a/api/src/interfaces/IMessage.ts
+++ b/api/src/interfaces/IMessage.ts
@@ -8,7 +8,9 @@ export interface IMessage {
     id: string,
     key?: string
   },
+  uuid?: string,
   command?: string,
   args?: string[],
   content: unknown
+  reply?: (content: unknown, options?: { args?: string[], toKey?: string }) => Promise<void>;
 }

--- a/api/src/interfaces/IWebsocketOptions.ts
+++ b/api/src/interfaces/IWebsocketOptions.ts
@@ -1,11 +1,18 @@
 import { Logger } from '@promisepending/logger.js';
 
+export interface IReconnectionOptions {
+  enabled: boolean,
+  maxAttempts?: number,
+  delay?: number
+}
+
 export interface IWebsocketOptions {
-    host: string
-    port: number
-    id: string
-    secureMode?: boolean
-    secureKey?: string
-    shardMode?: boolean
-    logger?: Logger
+  host: string
+  port: number
+  id: string
+  secureMode?: boolean
+  secureKey?: string
+  shardMode?: boolean
+  logger?: Logger
+  reconnection?: IReconnectionOptions
 }

--- a/api/src/websocket/WebSocketClient.ts
+++ b/api/src/websocket/WebSocketClient.ts
@@ -348,6 +348,9 @@ export class ArunaClient extends EventEmitter<ArunaEvents> {
       case '401':
         this.emit('unauthorized', parsedMessage);
         break;
+      case '403':
+        this.emit('forbidden', parsedMessage);
+        break;
       default:
         this.emit('message', parsedMessage);
         if (parsedMessage.command) this.emit(parsedMessage.command, parsedMessage);

--- a/api/src/websocket/parser.ts
+++ b/api/src/websocket/parser.ts
@@ -43,4 +43,13 @@ export class WebSocketParser {
   public static formatToString(from: { id: string, key?: string }, content: any, { type, command, target, args }: { type?: string, command?: string, target?: { id: string, key?: string }, args?: string[] }): string {
     return JSON.stringify(this.format(from, content, { type, command, target, args }));
   }
+
+  /**
+   * @private
+   */
+  public static formatToStringWithUUID(from: { id: string, key?: string }, uuid: string, content: any, { type, command, target, args }: { type?: string, command?: string, target?: { id: string, key?: string }, args?: string[] }): string {
+    const message = this.format(from, content, { type, command, target, args });
+    Object.assign(message, { uuid });
+    return JSON.stringify(message);
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arunacore",
-  "version": "1.0.0-BETA.4",
+  "version": "1.0.0-BETA.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "arunacore",
-      "version": "1.0.0-BETA.4",
+      "version": "1.0.0-BETA.5",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arunacore",
-  "version": "1.0.0-BETA.4",
+  "version": "1.0.0-BETA.5",
   "description": "ArunaCore is an open source websocket server made with nodejs for intercomunication between applications.",
   "main": "build/nodejs/src/main/start.js",
   "type": "module",

--- a/src/main/websocket/managers/messageHandler.ts
+++ b/src/main/websocket/managers/messageHandler.ts
@@ -29,13 +29,8 @@ export class MessageHandler {
 
     const fromConnection = this.connectionManager.getConnection(message.from.id);
 
-    if (!fromConnection && message.type === 'register') {
-      connection.close(1000, this.internalFormatToString('deprecated-register-method', { command: '410', target: { id: message.from.id }, type: 'disconnect' }));
-      return;
-    }
-
     if (!fromConnection) {
-      connection.send(this.internalFormatToString('unprocessable-entity', { command: '422', target: { id: message.from.id }, type: 'register' }));
+      connection.close(1000, this.internalFormatToString('unauthorized', { command: '401', target: { id: message.from.id }, type: 'disconnect' }));
       return;
     }
 
@@ -67,7 +62,7 @@ export class MessageHandler {
     }
 
     if (targetConnection.getIsSecure() && targetConnection.getSecureKey() !== message.target?.key) {
-      connection.send(this.internalFormatToString('unauthorized', { command: '401', target: { id: message.from.id } }));
+      connection.send(this.internalFormatToString('forbidden', { command: '403', target: { id: message.from.id } }));
       return;
     }
 
@@ -98,7 +93,7 @@ export class MessageHandler {
           break;
         }
         if (this.masterKey !== message.content) {
-          connection.send(this.internalFormatToString('unauthorized', { command: '401', target: { id: message.from.id } }));
+          connection.send(this.internalFormatToString('forbidden', { command: '403', target: { id: message.from.id } }));
           break;
         }
         var ids: string[] = Array.from(this.connectionManager.getAliveConnections().keys());

--- a/src/main/websocket/managers/messageHandler.ts
+++ b/src/main/websocket/managers/messageHandler.ts
@@ -75,7 +75,6 @@ export class MessageHandler {
 
     if (message.from.key) delete message.from.key;
     if (message.target?.key) delete message.target.key;
-    if (message.coreKey) delete message.coreKey;
 
     targetConnection.send(message);
   }
@@ -98,7 +97,7 @@ export class MessageHandler {
           connection.send(this.internalFormatToString('service-unavaliable', { command: '503', target: { id: message.from.id }, type: 'unavaliable' }));
           break;
         }
-        if (this.masterKey !== message.coreKey) {
+        if (this.masterKey !== message.content) {
           connection.send(this.internalFormatToString('unauthorized', { command: '401', target: { id: message.from.id } }));
           break;
         }
@@ -118,14 +117,12 @@ export class MessageHandler {
       (
         this.masterKey &&
         (
-          message.coreKey ||
           (
-            (
-              typeof message.content === 'string' ||
-              typeof message.content === typeof Array
-            ) &&
-            message.content.includes(this.masterKey)
-          ) ||
+            typeof message.content === 'string' ||
+            typeof message.content === typeof Array
+          ) &&
+          (message.content as (string | Array<string>)).includes(this.masterKey)
+          ||
           message.args?.includes(this.masterKey)
         )
       )

--- a/src/main/websocket/socket.ts
+++ b/src/main/websocket/socket.ts
@@ -107,7 +107,7 @@ export class Socket extends EventEmitter {
         id: appId,
         isAlive: true,
         connection: client,
-        apiVersion: apiVersion, // TODO: Create a good way to check if the client is using a supported api version
+        apiVersion: apiVersion,
         isSecure: !!userToken,
         secureKey: userToken,
         isSharded: false, // TODO: Implement sharding

--- a/src/tests/scripts/sendMessage3.ts
+++ b/src/tests/scripts/sendMessage3.ts
@@ -11,8 +11,8 @@ async function sendMessage3Test({ loggerClient, client, client2 }: ITestOptions)
       clearTimeout(timeout);
       return reject(new Error('Message 3 Received'));
     });
-    client.once('unauthorized', () => {
-      loggerClient.info('Client 1 Unauthorized as intended');
+    client.once('forbidden', () => {
+      loggerClient.info('Client 1 Forbidden as intended');
       clearTimeout(timeout);
       return resolve();
     });

--- a/src/tests/scripts/sendRequest.ts
+++ b/src/tests/scripts/sendRequest.ts
@@ -1,0 +1,36 @@
+import { IMessage } from 'arunacore-api';
+import { ITestOptions } from '../interfaces';
+
+async function sendRequestTest({ loggerClient, client2, client3 }: ITestOptions): Promise<void> {
+  return new Promise(async (resolve, reject) => {
+    const timeout = setTimeout(() => {
+      loggerClient.error('Request Timeout');
+      return reject(new Error('Request Timeout'));
+    }, 10000);
+
+    client3.once('request', async (message: IMessage) => {
+      loggerClient.info('Client 3 Received Request: ', message);
+      try {
+        await message.reply!('test', { toKey: 'test2' });
+        loggerClient.info('Client 3 Replied to Request');
+      } catch (e) {
+        loggerClient.error('Client 3 Failed to Reply to Request: ' + e);
+        return reject(e);
+      }
+    });
+
+    const response = await client2.request('test', { target: { id: 'client3', key: 'test3' } });
+    loggerClient.info('Request Response: ', response);
+    clearTimeout(timeout);
+
+    if (response.content === 'test') {
+      return resolve();
+    } else {
+      return reject(new Error(`Invalid Response Content: ${response.content}`));
+    }
+  });
+}
+
+export const name = 'Request Test';
+export const run = sendRequestTest;
+export const order = 8;


### PR DESCRIPTION
  - [FIX] Wrong management of `coreKey`
    - Fixed an issue where the `coreKey` was handled incorrectly, causing it to be always null, resulting in clients being unable to access restricted resources.

  - [FEAT] Split `401 Unauthorized` into `401 Unauthorized` and `403 Forbidden`  
    - Now, `401` is used when authentication fails (e.g., invalid secure key), while `403` is used when access is denied despite valid authentication (e.g., insufficient permissions, invalid key for specific target communication, invalid masterkey, etc.). 
    - This provides clearer feedback to clients about the nature of access issues.

  - [FEAT] Implemented `client.request()` method in `WebSocketClient`  
    - This method allows sending a message and awaiting a response, simplifying request-response interactions.
    - To use it, simply call `client.request(message)` and await the returned promise.
    - To respond to such request on the other side, handle the `request` event and reply using `message.reply`.

  - [CHORE] Improved code documentation and comments for better clarity and maintainability.